### PR TITLE
feat: individual step outputs with auto-masking

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - **Individual mode** (default): Map explicit environment variable names to SSM parameter paths.
 - **Path-based mode** (`by-path: true`): Fetch all parameters recursively under an SSM path. Keys are derived from the last path segment.
 
-Both modes support optional key transformation to UPPER_SNAKE_CASE.
+Both modes support optional key transformation to UPPER_SNAKE_CASE. All fetched values are auto-masked in logs via `setSecret` and available as individual step outputs.
 
 ## Usage
 
@@ -72,7 +72,7 @@ jobs:
 | `secret`           | In individual mode: a mapping of env var names to SSM parameter paths (key=value or JSON). In path-based mode: a single SSM path to enumerate.       | true     |         |
 | `with-decryption`  | If set to true, retrieves decrypted values for secure string parameters.                                                                             | false    | `false` |
 | `parameter-prefix` | An optional prefix to filter SSM parameter names. Only parameters matching this prefix will be fetched. Ignored in path-based mode.                  | false    | ""      |
-| `env-file-path`    | The file path where the environment variables will be saved. Defaults to `./`.                                                                        | false    | `./`    |
+| `env-file-path`    | The directory path where the .env file will be saved. If not provided, no .env file is created.                                                          | false    | ""     |
 | `is-json`          | Indicates whether the provided secret is in JSON format. Set to true if the secret is a JSON object. Ignored in path-based mode.                     | false    | false   |
 | `by-path`          | When set to true, the `secret` input is treated as a single SSM path. All parameters under that path are fetched recursively.                        | false    | `false` |
 | `transform-keys`   | When set to true, converts all environment variable keys to UPPER_SNAKE_CASE. Applies in both individual and path-based modes.                       | false    | `false` |
@@ -80,6 +80,18 @@ jobs:
 
 ## Outputs
 
-| Name  | Description                                       |
-| ----- | ------------------------------------------------- |
-| `env` | JSON string of the fetched environment variables. |
+Each SSM parameter is available as an individual step output at `${{ steps.<step-id>.outputs.<KEY> }}`. Values are automatically masked in workflow logs.
+
+Example:
+```yaml
+- name: Read SSM params
+  id: ssm
+  uses: Armadillidiid/ssm-get-parameters-action@v1
+  with:
+    secret: /my-app/prod
+    by-path: true
+    transform-keys: true
+
+- name: Use a param
+  run: echo "${{ steps.ssm.outputs.ECR_REPOSITORY_URI }}"
+```

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: ""
   env-file-path:
-    description: "The file path where the environment variables will be saved. Defaults to `./`."
+    description: "The directory path where the .env file will be saved. If not provided, no .env file is created."
     required: false
-    default: "./"
+    default: ""
   is-json:
     description: "Indicates whether the provided secret is in JSON format. Set to true if the secret is a JSON object."
     required: false
@@ -39,10 +39,6 @@ inputs:
     description: "When by-path is true, controls whether to recursively fetch parameters from sub-paths. Maps to the Recursive parameter of GetParametersByPath."
     required: false
     default: "true"
-
-outputs:
-  env:
-    description: "A JSON stringified object containing the environment variables fetched from SSM."
 
 runs:
   using: "node24"

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -1,3 +1,2 @@
 export const MAX_CONCURRENT_SSM_PROMISES = 3;
 export const ENV_FILENAME = ".env";
-export const ENV_OUTPUT_KEY = "env";

--- a/src/env.ts
+++ b/src/env.ts
@@ -16,17 +16,7 @@ const byPath: boolean = getBooleanInput("by-path");
 const transformKeys: boolean = getBooleanInput("transform-keys");
 const recursive: boolean = getBooleanInput("recursive");
 
-let envFilePath = "";
-try {
-	envFilePath = getEnvFilePath();
-} catch (error) {
-	if (error instanceof Error) {
-		core.error(`Validation failed: ${error.message}`);
-	} else {
-		core.error(`Validation failed: ${String(error)}`);
-	}
-	throw error;
-}
+const envFilePath = getEnvFilePath();
 
 export const env = {
 	SECRET: secret,
@@ -41,14 +31,16 @@ export const env = {
 
 function getEnvFilePath(): string {
 	const envFilePathInput: string = getInput("env-file-path");
+	if (!envFilePathInput) {
+		return "";
+	}
+
 	const resolvedPath: string = path.resolve(envFilePathInput);
 
-	// Validate if the path exists
 	if (!fs.existsSync(resolvedPath)) {
 		throw new Error(`The specified path does not exist: ${resolvedPath}`);
 	}
 
-	// Check if it's a directory
 	const stats = fs.statSync(resolvedPath);
 	if (!stats.isDirectory()) {
 		throw new Error(`The specified path is not a directory: ${resolvedPath}`);

--- a/src/env.ts
+++ b/src/env.ts
@@ -16,20 +16,17 @@ const byPath: boolean = getBooleanInput("by-path");
 const transformKeys: boolean = getBooleanInput("transform-keys");
 const recursive: boolean = getBooleanInput("recursive");
 
-const envFilePath = getEnvFilePath();
-
 export const env = {
 	SECRET: secret,
 	WITH_DECRYPTION: withDecryption,
 	PARAMETER_PREFIX: prefix,
-	ENV_FILE_PATH: envFilePath,
 	IS_JSON: isJSON,
 	BY_PATH: byPath,
 	TRANSFORM_KEYS: transformKeys,
 	RECURSIVE: recursive,
 };
 
-function getEnvFilePath(): string {
+export function getEnvFilePath(): string {
 	const envFilePathInput: string = getInput("env-file-path");
 	if (!envFilePathInput) {
 		return "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,7 @@
 import path from "node:path";
 import * as core from "@actions/core";
 import { Effect, Either, Schedule } from "effect";
-import {
-	ENV_FILENAME,
-	MAX_CONCURRENT_SSM_PROMISES,
-} from "./constant.js";
+import { ENV_FILENAME, MAX_CONCURRENT_SSM_PROMISES } from "./constant.js";
 import { env } from "./env.js";
 import type { ParsedSecret } from "./schemas.js";
 import {
@@ -110,10 +107,7 @@ const main = async (): Promise<void> => {
 	}
 
 	if (env.ENV_FILE_PATH) {
-		await saveEnvToPath(
-			path.join(env.ENV_FILE_PATH, ENV_FILENAME),
-			envValues,
-		);
+		await saveEnvToPath(path.join(env.ENV_FILE_PATH, ENV_FILENAME), envValues);
 	}
 
 	for (const [key, value] of envValues) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import * as core from "@actions/core";
 import { Effect, Either, Schedule } from "effect";
 import { ENV_FILENAME, MAX_CONCURRENT_SSM_PROMISES } from "./constant.js";
-import { env } from "./env.js";
+import { env, getEnvFilePath } from "./env.js";
 import type { ParsedSecret } from "./schemas.js";
 import {
 	fetchParameters,
@@ -15,6 +15,16 @@ import {
 } from "./utils.js";
 
 const main = async (): Promise<void> => {
+	let envFilePath: string;
+	try {
+		envFilePath = getEnvFilePath();
+	} catch (error) {
+		if (error instanceof Error) {
+			core.setFailed(error.message);
+		}
+		process.exit(1);
+	}
+
 	let envValues: [string, string][] = [];
 
 	if (env.BY_PATH) {
@@ -106,8 +116,8 @@ const main = async (): Promise<void> => {
 		process.exit();
 	}
 
-	if (env.ENV_FILE_PATH) {
-		await saveEnvToPath(path.join(env.ENV_FILE_PATH, ENV_FILENAME), envValues);
+	if (envFilePath) {
+		await saveEnvToPath(path.join(envFilePath, ENV_FILENAME), envValues);
 	}
 
 	for (const [key, value] of envValues) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,11 @@ const main = async (): Promise<void> => {
 
 	await saveEnvToPath(path.join(env.ENV_FILE_PATH, ENV_FILENAME), envValues);
 	core.setOutput(ENV_OUTPUT_KEY, JSON.stringify(Object.fromEntries(envValues)));
+
+	for (const [key, value] of envValues) {
+		core.setSecret(value);
+		core.setOutput(key, value);
+	}
 };
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import * as core from "@actions/core";
 import { Effect, Either, Schedule } from "effect";
 import {
 	ENV_FILENAME,
-	ENV_OUTPUT_KEY,
 	MAX_CONCURRENT_SSM_PROMISES,
 } from "./constant.js";
 import { env } from "./env.js";
@@ -110,8 +109,12 @@ const main = async (): Promise<void> => {
 		process.exit();
 	}
 
-	await saveEnvToPath(path.join(env.ENV_FILE_PATH, ENV_FILENAME), envValues);
-	core.setOutput(ENV_OUTPUT_KEY, JSON.stringify(Object.fromEntries(envValues)));
+	if (env.ENV_FILE_PATH) {
+		await saveEnvToPath(
+			path.join(env.ENV_FILE_PATH, ENV_FILENAME),
+			envValues,
+		);
+	}
 
 	for (const [key, value] of envValues) {
 		core.setSecret(value);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -141,6 +141,6 @@ export const saveEnvToPath = async (path: string, result: ParsedSecret) => {
 	core.info(`Saving environment variable: ${path}`);
 	const outputEnv = result.map(([key, value]) => `${key}=${value}`).join("\n");
 	await fs.writeFile(path, outputEnv, {
-		mode: "0644",
+		mode: 0o600,
 	});
 };


### PR DESCRIPTION
## Summary

Each SSM parameter is now available as an individual step output at `${{ steps.<id>.outputs.<KEY> }}` with automatic log masking via `core.setSecret()`.

### Changes

- **Individual outputs**: Each param is now `core.setOutput(key, value)` for direct access without `fromJSON`
- **Auto-masking**: `core.setSecret(value)` called for every param value — automatically hidden in logs
- **env-file-path optional**: Defaults to empty. No `.env` file created unless a path is specified. Improves security by not writing secrets to disk unnecessarily
- **Removed `env` JSON output**: Individual outputs replace the need for a JSON blob output

### Usage

```yaml
steps:
  - name: Read SSM params
    id: ssm
    uses: Armadillidiid/ssm-get-parameters-action@v1
    with:
      secret: /my-app/prod
      by-path: true
      transform-keys: true

  - name: Use a param
    run: echo "${{ steps.ssm.outputs.ECR_REPOSITORY_URI }}"
```

No `fromJSON` needed. Values are auto-masked in logs.